### PR TITLE
fix: updated test suite to match the new schema, fixed the async test to not run after tear down

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import * as core from "@actions/core";
 import { run } from "./run";
 
-run()
+export default run()
   .then((result) => {
     core?.setOutput("result", result);
+    return result;
   })
   .catch((e) => {
     console.error("Failed to run comment evaluation:", e);
     core?.setFailed(e.toString());
+    return e;
   });

--- a/tests/__mocks__/results/valid-configuration.json
+++ b/tests/__mocks__/results/valid-configuration.json
@@ -3,6 +3,7 @@
   "evmPrivateEncrypted": "kmpTKq5Wh9r9x5j3U9GqZr3NYnjK2g0HtbzeUBOuLC2y3x8ja_SKBNlB2AZ6LigXHP_HeMitftVUtzmoj8CFfVP9SqjWoL6IPku1hVTWkdTn97g1IxzmjydFxjdcf0wuDW1hvVtoq3Uw5yALABqxcQ",
   "incentives": {
     "enabled": true,
+    "requirePriceLabel": true,
     "contentEvaluator": {
       "enabled": true
     },
@@ -17,7 +18,7 @@
       "enabled": true,
       "multipliers": [
         {
-          "type": [
+          "targets": [
             "ISSUE",
             "ISSUER",
             "SPECIFICATION"
@@ -26,7 +27,7 @@
           "wordValue": 0.1
         },
         {
-          "type": [
+          "targets": [
             "ISSUE",
             "ISSUER",
             "COMMENTED"
@@ -35,7 +36,7 @@
           "wordValue": 0.2
         },
         {
-          "type": [
+          "targets": [
             "ISSUE",
             "ASSIGNEE",
             "COMMENTED"
@@ -44,7 +45,7 @@
           "wordValue": 0
         },
         {
-          "type": [
+          "targets": [
             "ISSUE",
             "COLLABORATOR",
             "COMMENTED"
@@ -53,7 +54,7 @@
           "wordValue": 0.1
         },
         {
-          "type": [
+          "targets": [
             "ISSUE",
             "CONTRIBUTOR",
             "COMMENTED"
@@ -62,7 +63,7 @@
           "wordValue": 0.1
         },
         {
-          "type": [
+          "targets": [
             "REVIEW",
             "ISSUER",
             "TASK"
@@ -71,7 +72,7 @@
           "wordValue": 0
         },
         {
-          "type": [
+          "targets": [
             "REVIEW",
             "ISSUER",
             "COMMENTED"
@@ -80,7 +81,7 @@
           "wordValue": 0.2
         },
         {
-          "type": [
+          "targets": [
             "REVIEW",
             "ASSIGNEE",
             "COMMENTED"
@@ -89,7 +90,7 @@
           "wordValue": 0.1
         },
         {
-          "type": [
+          "targets": [
             "REVIEW",
             "COLLABORATOR",
             "COMMENTED"
@@ -98,7 +99,7 @@
           "wordValue": 0.1
         },
         {
-          "type": [
+          "targets": [
             "REVIEW",
             "CONTRIBUTOR",
             "COMMENTED"

--- a/tests/process.issue.test.ts
+++ b/tests/process.issue.test.ts
@@ -220,6 +220,8 @@ describe("Modules tests", () => {
   });
 
   it("Should do a full run", async () => {
-    require("../src/index.ts");
+    const module = (await import("../src/index.ts")) as unknown as { default: Promise<string> };
+    const result = await module.default;
+    expect(result).toBeTruthy();
   });
 });


### PR DESCRIPTION
Relates to https://github.com/ubiquibot/conversation-rewards/actions/runs/9459442429 not running successfully.

QA run: https://github.com/Meniole/conversation-rewards/actions/runs/9459608093