### PR TITLE
ci: run knip-reporter on failure

### DIFF
--- a/.github/workflows/knip-reporter.yml
+++ b/.github/workflows/knip-reporter.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   knip-reporter:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion != 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,7 +36,6 @@ jobs:
           trim: true
 
       - name: Report knip results to pull request
-        if: ${{ github.event.workflow_run.conclusion != 'success' }}
         uses: gitcoindev/knip-reporter@main
         with:
           verbose: true


### PR DESCRIPTION
Check [this](https://github.com/ubiquibot/conversation-rewards/actions/runs/9588345425/job/26440189364) CI run which failed with error `Unable to download artifact(s): Artifact not found for name: knip-results `.

It happened because knip workflow [uploads](https://github.com/ubiquibot/conversation-rewards/blob/ba853c5d6606c1b694df36ac72050f6d5b0b20fb/.github/workflows/knip.yml#L27-L34) results only on failure while knip-reporter workflow [tries](https://github.com/ubiquibot/conversation-rewards/blob/ba853c5d6606c1b694df36ac72050f6d5b0b20fb/.github/workflows/knip-reporter.yml#L24-L28) to download knip results every time. So when there are no knip errors the knip-reporter workflow tries to download an artifact that doesn't exist.

This PR runs knip-reporter workflow only if [knip workflow](https://github.com/ubiquibot/conversation-rewards/blob/ba853c5d6606c1b694df36ac72050f6d5b0b20fb/.github/workflows/knip.yml) failed. This way the knip results artifact is always present and the `Unable to download artifact(s): Artifact not found for name: knip-results` error is gone (along with github notifications).

QA (no knip errors):
- Knip: https://github.com/rndquu/conversation-rewards/actions/runs/9588457290/job/26440524402?pr=3
- Knip reporter: https://github.com/rndquu/conversation-rewards/actions/runs/9588463220

QA (with knip errors):
- Knip: https://github.com/rndquu/conversation-rewards/actions/runs/9588471702/job/26440570139?pr=3
- Knip reporter: https://github.com/rndquu/conversation-rewards/actions/runs/9588478757