### PR TITLE
fix: waiting message is only displayed on issue completed

### DIFF
--- a/.github/workflows/compute.yml
+++ b/.github/workflows/compute.yml
@@ -41,7 +41,7 @@ jobs:
           script: |
             const comment_body = '\`\`\`diff\n+ Evaluating results. Please wait...';
             const obj = ${{ inputs.eventPayload }}
-            if (obj.issue && "${{ inputs.eventName }}" === "issues.closed") {
+            if (obj.issue && "${{ inputs.eventName }}" === "issues.closed" && obj.issue.state_reason === "completed") {
               const response = await github.rest.issues.createComment({
                 owner: obj.repository.owner.login,
                 repo: obj.repository.name,


### PR DESCRIPTION
Resolves #88

QA: https://github.com/Meniole/conversation-rewards/issues/1#issuecomment-2306309319

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
